### PR TITLE
Document the authentication contract (closes #44)

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,3 +43,9 @@ All non-auth routes require an `x-auth-token` header (see Authentication).
 ## Authentication
 
 Stateless JWT in the `x-auth-token` header. Payload: `{ user: { id } }`, signed with `TOKEN_SECRET`, expiring after `TOKEN_EXPIRY` (default `5 days`).
+
+### Example request
+
+```bash
+curl -H "x-auth-token: <your-token>" http://localhost:8000/api/metrics
+```


### PR DESCRIPTION
Closes #44

Documents the header name, token payload shape, and expiry so the cross-stack auth contract is discoverable.