### PR TITLE
Validate ObjectId on id-taking routes (closes #46)

### DIFF
--- a/middleware/validateIdParam.js
+++ b/middleware/validateIdParam.js
@@ -1,0 +1,12 @@
+const mongoose = require("mongoose");
+
+// Validates an _id supplied via query or body before it reaches a Mongo query.
+const validateIdParam = (req, res, next) => {
+  const id = req.query._id || req.body._id;
+  if (!mongoose.Types.ObjectId.isValid(id)) {
+    return res.status(400).json({ errors: [{ msg: "Invalid ID" }] });
+  }
+  next();
+};
+
+module.exports = validateIdParam;

--- a/routes/metrics.js
+++ b/routes/metrics.js
@@ -15,16 +15,17 @@ const {
   getLastestMetricsWagesById,
 } = require("../controllers/wage.js");
 const auth = require("../middleware/auth");
+const validateIdParam = require("../middleware/validateIdParam");
 
 router.post("/", auth, addMetrics);
-router.put("/", auth, updateMetrics);
+router.put("/", auth, validateIdParam, updateMetrics);
 router.get("/", auth, getUserMetrics);
-router.delete("/", auth, deleteMetricById);
+router.delete("/", auth, validateIdParam, deleteMetricById);
 router.post("/wage", auth, addMetricsWage);
 router.put("/wage", auth, updateMetricsWage);
 router.get("/wage", auth, getUserMetricsAllWages);
 router.get("/wage/today", auth, getUserMetricsAllTodayWages);
-router.delete("/wage", auth, deleteMetricWageById);
+router.delete("/wage", auth, validateIdParam, deleteMetricWageById);
 router.get("/wage/lastest", auth, getLastestMetricsWagesById);
 
 module.exports = router;


### PR DESCRIPTION
Closes #46

Adds a middleware that validates the `_id` in the query/body and applies it to the metrics update/delete and wage delete routes, returning 400 instead of a 500 CastError.