### PR TITLE
Use cross-env in the test script (closes #51)

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "start": "node ./bin/www",
     "dev": "nodemon ./bin/www",
     "debug": "nodemon  --inspect ./bin/www",
-    "test": "NODE_ENV=test ./node_modules/.bin/mocha --exit --timeout 30000",
+    "test": "cross-env NODE_ENV=test ./node_modules/.bin/mocha --exit --timeout 30000",
     "heroku-postbuild": "cd client && npm install --only=dev && npm install && npm run build"
   },
   "author": "",


### PR DESCRIPTION
Closes #51

Uses `cross-env` (already a dependency) so the `test` script's `NODE_ENV=test` works on Windows too.