### PR TITLE
Centralize JWT expiry and fail fast on missing secret (closes #54)

### DIFF
--- a/bin/www
+++ b/bin/www
@@ -3,6 +3,11 @@
 /* Sets up the environment variables from your .env file*/
 require('dotenv').config();
 
+if (!process.env.TOKEN_SECRET) {
+  console.error('FATAL: TOKEN_SECRET environment variable is not set');
+  process.exit(1);
+}
+
 /**
  * Module dependencies.
  */

--- a/controllers/auth.js
+++ b/controllers/auth.js
@@ -40,7 +40,7 @@ exports.register = async (req, res, next) => {
     jwt.sign(
       payload,
       process.env.TOKEN_SECRET,
-      { expiresIn: "5 days" },
+      { expiresIn: process.env.TOKEN_EXPIRY || "5 days" },
       (err, token) => {
         if (err) throw err;
         res.json({ doc: token });
@@ -82,7 +82,7 @@ exports.login = async (req, res) => {
     jwt.sign(
       payload,
       process.env.TOKEN_SECRET,
-      { expiresIn: "5 days" },
+      { expiresIn: process.env.TOKEN_EXPIRY || "5 days" },
       (err, token) => {
         if (err) throw err;
         res.json({ doc: token });


### PR DESCRIPTION
Closes #54

Reads token expiry from `TOKEN_EXPIRY` (default `5 days`) instead of a duplicated hardcoded value, and aborts startup if `TOKEN_SECRET` is unset.