### PR TITLE
Use production-appropriate morgan format (closes #55)

### DIFF
--- a/server.js
+++ b/server.js
@@ -32,7 +32,7 @@ const { json, urlencoded } = express;
 var app = express();
 
 app.use(cors());
-app.use(logger("dev"));
+app.use(logger(process.env.NODE_ENV === "production" ? "combined" : "dev"));
 app.use(json());
 app.use(urlencoded({ extended: false }));
 app.use(express.static(path.join(__dirname, "client", "build")));


### PR DESCRIPTION
Closes #55

Uses the `combined` log format in production and `dev` otherwise.