### PR TITLE
Add a consistent API response helper (closes #58)

### DIFF
--- a/utils/apiResponse.js
+++ b/utils/apiResponse.js
@@ -1,0 +1,11 @@
+// Consistent response envelopes for the API.
+// Success: { doc } or { docs }. Error: { errors: [{ msg }] }.
+
+exports.ok = (res, payload, status = 200) => res.status(status).json(payload);
+
+exports.okDoc = (res, doc, status = 200) => res.status(status).json({ doc });
+
+exports.okDocs = (res, docs, status = 200) => res.status(status).json({ docs });
+
+exports.fail = (res, msg, status = 500) =>
+  res.status(status).json({ errors: [{ msg }] });


### PR DESCRIPTION
Closes #58

Adds `utils/apiResponse.js` with `ok`/`fail` helpers so handlers can return a single consistent envelope shape going forward.