### PR TITLE
Clarify the 'wage' domain naming (closes #60)

### DIFF
--- a/models/wage.js
+++ b/models/wage.js
@@ -19,4 +19,10 @@ const wageSchema = new Schema(
     collection: "wage",
   }
 );
+// NOTE: `wage` stores a recorded metric value (e.g. weight, heart rate),
+// not a salary. The field name is legacy; `value` is a read alias.
+wageSchema.virtual("value").get(function () {
+  return this.wage;
+});
+
 module.exports = mongoose.model("wage", wageSchema);


### PR DESCRIPTION
Closes #60

Documents that `wage` stores a recorded metric value (not a salary) and exposes a non-breaking `value` virtual alias, paving the way for a future rename.