### PR TITLE
Make bcrypt cost factor configurable (closes #61)

### DIFF
--- a/controllers/auth.js
+++ b/controllers/auth.js
@@ -25,7 +25,8 @@ exports.register = async (req, res, next) => {
       password,
     });
 
-    const salt = await bcrypt.genSalt(10);
+    const SALT_ROUNDS = parseInt(process.env.BCRYPT_SALT_ROUNDS, 10) || 12;
+    const salt = await bcrypt.genSalt(SALT_ROUNDS);
     user.password = await bcrypt.hash(password, salt);
     Metrics.insertM
 


### PR DESCRIPTION
Closes #61

Reads the bcrypt cost factor from `BCRYPT_SALT_ROUNDS` (default 12, up from the hardcoded 10).