### PR TITLE
Add health check and graceful shutdown (closes #62)

### DIFF
--- a/bin/www
+++ b/bin/www
@@ -37,6 +37,11 @@ server.listen(port);
 server.on('error', onError);
 server.on('listening', onListening);
 
+process.on('SIGTERM', () => {
+  console.log('SIGTERM received, shutting down gracefully');
+  server.close(() => process.exit(0));
+});
+
 /**
  * Normalize a port into a number, string, or false.
  */

--- a/server.js
+++ b/server.js
@@ -34,6 +34,10 @@ app.use(json());
 app.use(urlencoded({ extended: false }));
 app.use(express.static(path.join(__dirname, "client", "build")));
 
+app.get("/api/health", (req, res) => {
+  res.status(200).json({ status: "ok", uptime: process.uptime() });
+});
+
 app.use("/api/auth", authRoutes);
 app.use("/api/metrics", metricsRoutes);
 app.use("/api/group", groupRoutes);


### PR DESCRIPTION
Closes #62

Adds a lightweight `/api/health` endpoint and a `SIGTERM` handler that closes the HTTP server before exit.