### PR TITLE
Add rate limiting to auth routes (closes #38)

### DIFF
--- a/middleware/rateLimiter.js
+++ b/middleware/rateLimiter.js
@@ -1,0 +1,12 @@
+const rateLimit = require("express-rate-limit");
+
+// Strict limiter for authentication endpoints to slow brute-force attacks.
+const authLimiter = rateLimit({
+  windowMs: 15 * 60 * 1000, // 15 minutes
+  max: 10, // max attempts per window per IP
+  standardHeaders: true,
+  legacyHeaders: false,
+  message: { errors: [{ msg: "Too many attempts, please try again later." }] },
+});
+
+module.exports = authLimiter;

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "cross-env": "^7.0.3",
     "dotenv": "^16.0.3",
     "express": "^4.18.2",
+    "express-rate-limit": "^6.7.0",
     "express-session": "^1.17.3",
     "express-validator": "^6.15.0",
     "helmet": "^6.0.1",

--- a/routes/auth.js
+++ b/routes/auth.js
@@ -3,9 +3,10 @@ const router = express.Router();
 
 const { register, login, loadUser } = require("../controllers/auth.js");
 const auth = require("../middleware/auth");
+const authLimiter = require("../middleware/rateLimiter");
 
 router.get("/loadUser", auth, loadUser); // load user
-router.post("/register", register);
-router.post("/login", login);
+router.post("/register", authLimiter, register);
+router.post("/login", authLimiter, login);
 
 module.exports = router;


### PR DESCRIPTION
Closes #38

Adds `express-rate-limit` and applies a strict limiter to `/register` and `/login` to slow brute-force and signup spam.