### PR TITLE
Stop leaking internal error details to clients (closes #41)

### DIFF
--- a/server.js
+++ b/server.js
@@ -67,13 +67,15 @@ app.use(function (req, res, next) {
 
 // error handler
 app.use(function (err, req, res, next) {
-  // set locals, only providing error in development
-  console.log(err);
-  res.locals.message = err.message;
-  res.locals.error = req.app.get("env") === "development" ? err : {};
-  // render the error page
+  const isDev = req.app.get("env") === "development";
+  if (isDev) console.error(err);
   res.status(err.status || 500);
-  res.json({ error: err });
+  res.json({
+    error: {
+      message: err.message || "Server error",
+      ...(isDev ? { stack: err.stack } : {}),
+    },
+  });
 });
 
 module.exports = app;


### PR DESCRIPTION
Closes #41

The global error handler now returns a generic message in production and only includes the stack in development.