### PR TITLE
Remove dead `Metrics.insertM` statement in register (closes #42)

### DIFF
--- a/controllers/auth.js
+++ b/controllers/auth.js
@@ -27,7 +27,6 @@ exports.register = async (req, res, next) => {
 
     const salt = await bcrypt.genSalt(10);
     user.password = await bcrypt.hash(password, salt);
-    Metrics.insertM
 
     await user.save();
 


### PR DESCRIPTION
Closes #42

Removes the stray, no-op `Metrics.insertM` line left over from the commented-out default-metrics seeding.