### PR TITLE
Make Mongo connection environment-aware (closes #47)

### DIFF
--- a/config/mongoose.js
+++ b/config/mongoose.js
@@ -1,12 +1,17 @@
 const mongoose = require("mongoose");
 const dotenv = require("dotenv");
 dotenv.config();
+
+const env = process.env.NODE_ENV || "development";
+const uri =
+  env === "test"
+    ? process.env.MONGODB_URI_TEST
+    : env === "production"
+    ? process.env.MONGODB_URI_PRODUCTION
+    : process.env.MONGODB_URI_DEV || process.env.MONGODB_URI_PRODUCTION;
+
 mongoose
-  .connect(process.env.MONGODB_URI_PRODUCTION, {
-    useNewUrlParser: true,
-    useUnifiedTopology: true,
-    useFindAndModify: false,
-  })
+  .connect(uri)
   .catch((err) => console.error("Connection error :" + err));
 const db = mongoose.connection;
 


### PR DESCRIPTION
Closes #47

`config/mongoose.js` now selects the URI based on `NODE_ENV` (test/production/dev) and removes the deprecated connection options.