### PR TITLE
Upgrade Mongoose off EOL v5 (closes #48)

### DIFF
--- a/bin/www
+++ b/bin/www
@@ -98,11 +98,7 @@ function onListening() {
 function connectDatabase() {
   //option object to avoid deprecation warnings
   mongoose
-    .connect(process.env.MONGODB_URI_PRODUCTION, {
-      useNewUrlParser: true,
-      useCreateIndex: true,
-      useUnifiedTopology: true,
-    })
+    .connect(process.env.MONGODB_URI_PRODUCTION)
     .catch((e) => console.error('Connection error :' + e));
 
   //check pending connection

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "jsonwebtoken": "^9.0.0",
     "lodash": "^4.17.21",
     "mongodb": "^5.4.0",
-    "mongoose": "^5.9.6",
+    "mongoose": "^7.6.3",
     "morgan": "^1.10.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Closes #48

Bumps `mongoose` to `^7.6.3` and removes the deprecated `useNewUrlParser`/`useCreateIndex`/`useUnifiedTopology` options in `bin/www` (no-ops/removed in v7).

> Note: requires a regression pass before merge.