### PR TITLE
Remove commented-out dead code (closes #50)

### DIFF
--- a/models/user.js
+++ b/models/user.js
@@ -1,5 +1,4 @@
 const mongoose = require("mongoose");
-const Metrics = require("./metrics");
 const Schema = mongoose.Schema;
 const userSchema = new Schema(
   {

--- a/server.js
+++ b/server.js
@@ -19,9 +19,6 @@ const path = require("path");
 const createError = require("http-errors");
 const cors = require("cors");
 const express = require("express");
-// const session = require("express-session");
-// const MongoStore = require("connect-mongo")(session);
-// const storeOptions = require("./config/storeOptions");
 const logger = require("morgan");
 const authRoutes = require("./routes/auth");
 const metricsRoutes = require("./routes/metrics");
@@ -36,21 +33,6 @@ app.use(logger("dev"));
 app.use(json());
 app.use(urlencoded({ extended: false }));
 app.use(express.static(path.join(__dirname, "client", "build")));
-
-// app.use(
-//   session({
-//     name: "sess_calendapp",
-//     secret: process.env.SESS_SECRET,
-//     store: new MongoStore(storeOptions),
-//     resave: false,
-//     saveUninitialized: false,
-//     cookie: {
-//       maxAge: 1000 * 60 * 60,
-//       httpOnly: false,
-//       secure: false,
-//     },
-//   })
-// );
 
 app.use("/api/auth", authRoutes);
 app.use("/api/metrics", metricsRoutes);


### PR DESCRIPTION
Closes #50

Removes the commented-out `express-session`/`connect-mongo` block in `server.js` and the unused `Metrics` import in `models/user.js`.