### PR TITLE
Run metric-delete cascade in a transaction (closes #57)

### DIFF
--- a/controllers/metrics.js
+++ b/controllers/metrics.js
@@ -62,18 +62,23 @@ exports.getUserMetrics = async (req, res, next) => {
 };
 
 exports.deleteMetricById = async (req, res, next) => {
+  const mongoose = require("mongoose");
+  const session = await mongoose.startSession();
   try {
-    const metric = await Metrics.findOne({ _id: req.query._id });
-    await Wage.deleteMany({ metricsId: req.query._id });
-    await Group.updateMany(
-      { contents: req.query._id },
-      { $pull: { contents: req.query._id } }
-    );
-
-    metric.delete();
+    await session.withTransaction(async () => {
+      await Wage.deleteMany({ metricsId: req.query._id }, { session });
+      await Group.updateMany(
+        { contents: req.query._id },
+        { $pull: { contents: req.query._id } },
+        { session }
+      );
+      await Metrics.deleteOne({ _id: req.query._id }, { session });
+    });
     res.status(200).json();
   } catch (err) {
     console.error(err.message);
     res.status(500).json({ errors: [{ msg: "Server error!" }] });
+  } finally {
+    session.endSession();
   }
 };


### PR DESCRIPTION
Closes #57

Wraps the wage/group/metric cascade in a single session transaction so a mid-cascade failure rolls back instead of leaving orphaned data.

> Note: transactions require a replica set / Atlas.