### PR TITLE
Stop swallowing errors in wage controller (closes #59)

### DIFF
--- a/controllers/wage.js
+++ b/controllers/wage.js
@@ -78,8 +78,8 @@ exports.getLastestMetricsWagesById = async (req, res) => {
       .limit(3);
     res.status(200).json({ docs: wages });
   } catch (err) {
-    // console.error(err.message);
-    // res.status(500).json({ errors: [{ msg: "Server error!" }] });
+    console.error(err.message);
+    res.status(500).json({ errors: [{ msg: "Server error!" }] });
   }
 };
 exports.deleteMetricWageById = async (req, res) => {


### PR DESCRIPTION
Closes #59

Restores the error log and 500 response in `getLastestMetricsWagesById`, which previously returned nothing on failure and could hang the client.